### PR TITLE
各処理をクラスごとに分ける

### DIFF
--- a/code_review/work/koki-sato/PHASE2/step1/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step1/sample.php
@@ -46,7 +46,7 @@ class TrainPlan
     public function useStudentDiscount()
     {
         // PHASE.2 step.1 学割料金を求めるメソッドを完成させる
-        $this->price *= 1 - self::STUDENT_DISCOUNT_COEFFICIENT;
+        $this->price = floor($this->price * (1 - self::STUDENT_DISCOUNT_COEFFICIENT));
     }
 
     // PHASE.2 step.1 往復代を求めるメソッドを追加する
@@ -91,7 +91,8 @@ class HotelPlan
     public function selectHotelRank($hotel_rank)
     {
         if (!array_key_exists($hotel_rank, self::HOTEL_ROOM_RANK_ADD_FEES)) {
-            return "正しいランクを選択して下さい\n";
+            echo "正しいランクを選択して下さい\n";
+            exit;
         }
         $this->price += self::HOTEL_ROOM_RANK_ADD_FEES[$hotel_rank];
     }
@@ -129,9 +130,7 @@ class TravelPrice
     public function getTotalPrice()
     {
         // PHASE.2 step.1 配列の合計金額を求める処理を完成させる
-        foreach ($this->prices as $price) {
-            $this->total_price += $price;
-        }
+        $this->total_price += array_sum($this->prices);
         return $this->total_price;
     }
 }

--- a/code_review/work/koki-sato/PHASE2/step1/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step1/sample.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * 交通費を求める
+ **/
+// 学割のきいた電車賃の往復代を求める
+const TRAIN_PRICE = 12500;
+// 学割係数
+const STUDENT_DISCOUNT_COEFFICIENT = 0.2;
+
+// 学割電車運賃を計算
+$student_discount_price = floor(TRAIN_PRICE * (1 - STUDENT_DISCOUNT_COEFFICIENT));
+// 学割往復交通費
+$round_trip = $student_discount_price * 2;
+
+echo "交通費： " . $round_trip . "円";
+echo "\n";
+
+
+/**
+ * 以下は交通費を求める際にクラスを使用したサンプルになります
+ **/
+//$train_plan = new TrainPlan(12500);
+//$train_plan->useStudentDiscount();
+//$round_trip = $train_plan->getRoundTripPrice();
+
+
+
+/**
+ * ホテル代を求める
+ **/
+// ホテル部屋代
+const HOTEL_ROOM_PRICE = 5000;
+// 喫煙ルームオプション代
+const SMOKER_COST = 1000;
+// ホテルの部屋別ランク料金
+const HOTEL_ROOM_RANK_ADD_FEES = [
+    'normal' => 0,
+    'bronze' => 3000,
+    'silver' => 5000,
+    'gold' => 8000
+];
+// 食事料金
+const MEAL_ADD_FEES = [
+    'breakfast' => 500,
+    'dinner' => 800
+];
+
+// 朝食とるorとらない
+$has_breakfast = true;
+// 夕食とるorとらない
+$has_dinner = false;
+// 喫煙or禁煙
+$is_smoker = false;
+// ホテルの部屋ランク
+$select_hotel_rank = 'gold';
+
+
+// ホテル代初期値設定
+$hotel_price = HOTEL_ROOM_PRICE;
+
+// 朝食代加算
+if ($has_breakfast === true) {
+    $hotel_price += MEAL_ADD_FEES['breakfast'];
+}
+// 夕食代加算
+if ($has_dinner === true) {
+    $hotel_price += MEAL_ADD_FEES['dinner'];
+}
+// 喫煙ルームオプション代加算
+if ($is_smoker === true) {
+    $hotel_price += SMOKER_COST;
+}
+// ホテルランク代加算
+if (!array_key_exists($select_hotel_rank, HOTEL_ROOM_RANK_ADD_FEES)) {
+    echo "正しいランクを選択して下さい\n";
+    exit;
+}
+$hotel_price += HOTEL_ROOM_RANK_ADD_FEES[$select_hotel_rank];
+
+echo "ホテル代： " . $hotel_price . "円";
+echo "\n";
+
+
+/**
+ * 旅費合計を求める
+ **/
+$total_price = $round_trip + $hotel_price;
+echo "旅費合計： " . $total_price . "円";
+
+
+class TrainPlan
+{
+    const STUDENT_DISCOUNT_COEFFICIENT = 0.2;
+    private $price = 0;
+
+
+    function __construct($price)
+    {
+        $this->price = $price;
+    }
+
+    public function useStudentDiscount()
+    {
+        // PHASE.2 step.1 学割料金を求めるメソッドを完成させる
+    }
+
+    // PHASE.2 step.1 往復代を求めるメソッドを追加する
+
+}
+
+class HotelPlan
+{
+    // 喫煙ルームオプション代
+    const SMOKER_COST = 1000;
+    // ホテルの部屋別ランク料金
+    const HOTEL_ROOM_RANK_ADD_FEES = [
+        'normal' => 0,
+        'bronze' => 3000,
+        'silver' => 5000,
+        'gold' => 8000
+    ];
+    // 食事料金
+    const MEAL_ADD_FEES = [
+        'breakfast' => 500,
+        'dinner' => 800
+    ];
+
+    private $price = 0;
+
+
+    public function __construct($price)
+    {
+        $this->price = $price;
+    }
+
+    // PHASE.2 step.1 喫煙可能部屋を使うメソッドを追加する
+
+    // PHASE.2 step.1 ホテルのランクを選択するメソッドを追加する
+
+    // PHASE.2 step.1 朝食を食べるメソッドを追加する
+
+    // PHASE.2 step.1 夕食を食べるメソッドを追加する
+
+    public function getTotalPrice()
+    {
+        return $this->price;
+    }
+}
+
+class TravelPrice
+{
+    private $total_price = 0;
+    private $prices = [];
+
+    public function __construct($round_trip_price, $hotel_price)
+    {
+        // PHASE.2 step.1 配列"$prices"に引数の値ををそれぞれ格納する
+    }
+
+    public function getTotalPrice()
+    {
+        // PHASE.2 step.1 配列の合計金額を求める処理を完成させる
+        return $this->total_price;
+    }
+}

--- a/code_review/work/koki-sato/PHASE2/step1/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step1/sample.php
@@ -2,28 +2,12 @@
 /**
  * 交通費を求める
  **/
-// 学割のきいた電車賃の往復代を求める
-const TRAIN_PRICE = 12500;
-// 学割係数
-const STUDENT_DISCOUNT_COEFFICIENT = 0.2;
 
-// 学割電車運賃を計算
-$student_discount_price = floor(TRAIN_PRICE * (1 - STUDENT_DISCOUNT_COEFFICIENT));
-// 学割往復交通費
-$round_trip = $student_discount_price * 2;
+$train_plan = new TrainPlan(12500);
+$train_plan->useStudentDiscount();
+$round_trip = $train_plan->getRoundTripPrice();
 
-echo "交通費： " . $round_trip . "円";
-echo "\n";
-
-
-/**
- * 以下は交通費を求める際にクラスを使用したサンプルになります
- **/
-//$train_plan = new TrainPlan(12500);
-//$train_plan->useStudentDiscount();
-//$round_trip = $train_plan->getRoundTripPrice();
-
-
+echo "交通費： " . $round_trip . "円\n";
 
 /**
  * ホテル代を求める
@@ -102,10 +86,14 @@ class TrainPlan
     public function useStudentDiscount()
     {
         // PHASE.2 step.1 学割料金を求めるメソッドを完成させる
+        $this->price *= 1 - STUDENT_DISCOUNT_COEFFICIENT;
     }
 
     // PHASE.2 step.1 往復代を求めるメソッドを追加する
-
+    public function getRoundTripPrice()
+    {
+        return $this->price * 2;
+    }
 }
 
 class HotelPlan

--- a/code_review/work/koki-sato/PHASE2/step1/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step1/sample.php
@@ -130,7 +130,7 @@ class TravelPrice
     public function getTotalPrice()
     {
         // PHASE.2 step.1 配列の合計金額を求める処理を完成させる
-        $this->total_price += array_sum($this->prices);
+        $this->total_price = array_sum($this->prices);
         return $this->total_price;
     }
 }

--- a/code_review/work/koki-sato/PHASE2/step1/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step1/sample.php
@@ -12,33 +12,12 @@ echo "交通費： " . $round_trip . "円\n";
 /**
  * ホテル代を求める
  **/
-// ホテル部屋代
-const HOTEL_ROOM_PRICE = 5000;
-// 朝食とるorとらない
-$has_breakfast = true;
-// 夕食とるorとらない
-$has_dinner = true;
-// 喫煙or禁煙
-$is_smoker = true;
-// ホテルの部屋ランク
-$select_hotel_rank = 'silver';
 
-$hotel_plan = new HotelPlan(HOTEL_ROOM_PRICE);
-// 朝食代加算
-if ($has_breakfast === true) {
-    $hotel_plan->eatBreakfast();
-}
-// 夕食代加算
-if ($has_dinner === true) {
-    $hotel_plan->eatDinner();
-}
-// 喫煙ルームオプション代加算
-if ($is_smoker === true) {
-    $hotel_plan->useSmokingRoom();
-}
-// ホテルランク代加算
-$hotel_plan->selectHotelRank($select_hotel_rank);
-
+$hotel_plan = new HotelPlan(5000);
+$hotel_plan->eatBreakfast();
+$hotel_plan->eatDinner();
+$hotel_plan->useSmokingRoom();
+$hotel_plan->selectHotelRank('silver');
 $hotel_price = $hotel_plan->getTotalPrice();
 
 echo "ホテル代： " . $hotel_price . "円";

--- a/code_review/work/koki-sato/PHASE2/step1/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step1/sample.php
@@ -14,52 +14,32 @@ echo "交通費： " . $round_trip . "円\n";
  **/
 // ホテル部屋代
 const HOTEL_ROOM_PRICE = 5000;
-// 喫煙ルームオプション代
-const SMOKER_COST = 1000;
-// ホテルの部屋別ランク料金
-const HOTEL_ROOM_RANK_ADD_FEES = [
-    'normal' => 0,
-    'bronze' => 3000,
-    'silver' => 5000,
-    'gold' => 8000
-];
-// 食事料金
-const MEAL_ADD_FEES = [
-    'breakfast' => 500,
-    'dinner' => 800
-];
-
 // 朝食とるorとらない
 $has_breakfast = true;
 // 夕食とるorとらない
-$has_dinner = false;
+$has_dinner = true;
 // 喫煙or禁煙
-$is_smoker = false;
+$is_smoker = true;
 // ホテルの部屋ランク
-$select_hotel_rank = 'gold';
+$select_hotel_rank = 'silver';
 
-
-// ホテル代初期値設定
-$hotel_price = HOTEL_ROOM_PRICE;
-
+$hotel_plan = new HotelPlan(HOTEL_ROOM_PRICE);
 // 朝食代加算
 if ($has_breakfast === true) {
-    $hotel_price += MEAL_ADD_FEES['breakfast'];
+    $hotel_plan->eatBreakfast();
 }
 // 夕食代加算
 if ($has_dinner === true) {
-    $hotel_price += MEAL_ADD_FEES['dinner'];
+    $hotel_plan->eatDinner();
 }
 // 喫煙ルームオプション代加算
 if ($is_smoker === true) {
-    $hotel_price += SMOKER_COST;
+    $hotel_plan->useSmokingRoom();
 }
 // ホテルランク代加算
-if (!array_key_exists($select_hotel_rank, HOTEL_ROOM_RANK_ADD_FEES)) {
-    echo "正しいランクを選択して下さい\n";
-    exit;
-}
-$hotel_price += HOTEL_ROOM_RANK_ADD_FEES[$select_hotel_rank];
+$hotel_plan->selectHotelRank($select_hotel_rank);
+
+$hotel_price = $hotel_plan->getTotalPrice();
 
 echo "ホテル代： " . $hotel_price . "円";
 echo "\n";
@@ -86,7 +66,7 @@ class TrainPlan
     public function useStudentDiscount()
     {
         // PHASE.2 step.1 学割料金を求めるメソッドを完成させる
-        $this->price *= 1 - STUDENT_DISCOUNT_COEFFICIENT;
+        $this->price *= 1 - self::STUDENT_DISCOUNT_COEFFICIENT;
     }
 
     // PHASE.2 step.1 往復代を求めるメソッドを追加する
@@ -122,12 +102,31 @@ class HotelPlan
     }
 
     // PHASE.2 step.1 喫煙可能部屋を使うメソッドを追加する
+    public function useSmokingRoom()
+    {
+        $this->price += self::SMOKER_COST;
+    }
 
     // PHASE.2 step.1 ホテルのランクを選択するメソッドを追加する
+    public function selectHotelRank($hotel_rank)
+    {
+        if (!array_key_exists($hotel_rank, self::HOTEL_ROOM_RANK_ADD_FEES)) {
+            return "正しいランクを選択して下さい\n";
+        }
+        $this->price += self::HOTEL_ROOM_RANK_ADD_FEES[$hotel_rank];
+    }
 
     // PHASE.2 step.1 朝食を食べるメソッドを追加する
+    public function eatBreakfast()
+    {
+        $this->price += self::MEAL_ADD_FEES['breakfast'];
+    }
 
     // PHASE.2 step.1 夕食を食べるメソッドを追加する
+    public function eatDinner()
+    {
+        $this->price += self::MEAL_ADD_FEES['dinner'];
+    }
 
     public function getTotalPrice()
     {

--- a/code_review/work/koki-sato/PHASE2/step1/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step1/sample.php
@@ -27,7 +27,9 @@ echo "\n";
 /**
  * 旅費合計を求める
  **/
-$total_price = $round_trip + $hotel_price;
+
+$travel_price = new TravelPrice($round_trip, $hotel_price);
+$total_price = $travel_price->getTotalPrice();
 echo "旅費合計： " . $total_price . "円";
 
 
@@ -121,11 +123,16 @@ class TravelPrice
     public function __construct($round_trip_price, $hotel_price)
     {
         // PHASE.2 step.1 配列"$prices"に引数の値ををそれぞれ格納する
+        $this->prices['round_trip_price'] = $round_trip_price;
+        $this->prices['hotel_price'] = $hotel_price;
     }
 
     public function getTotalPrice()
     {
         // PHASE.2 step.1 配列の合計金額を求める処理を完成させる
+        foreach ($this->prices as $price) {
+          $this->total_price += $price;
+        }
         return $this->total_price;
     }
 }

--- a/code_review/work/koki-sato/PHASE2/step1/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step1/sample.php
@@ -20,8 +20,7 @@ $hotel_plan->useSmokingRoom();
 $hotel_plan->selectHotelRank('silver');
 $hotel_price = $hotel_plan->getTotalPrice();
 
-echo "ホテル代： " . $hotel_price . "円";
-echo "\n";
+echo "ホテル代： " . $hotel_price . "円\n";
 
 
 /**
@@ -30,7 +29,7 @@ echo "\n";
 
 $travel_price = new TravelPrice($round_trip, $hotel_price);
 $total_price = $travel_price->getTotalPrice();
-echo "旅費合計： " . $total_price . "円";
+echo "旅費合計： " . $total_price . "円\n";
 
 
 class TrainPlan
@@ -131,7 +130,7 @@ class TravelPrice
     {
         // PHASE.2 step.1 配列の合計金額を求める処理を完成させる
         foreach ($this->prices as $price) {
-          $this->total_price += $price;
+            $this->total_price += $price;
         }
         return $this->total_price;
     }


### PR DESCRIPTION
## WHY

- 現状、ホテルに泊まる際のオプションが考慮されていない
  - 朝食・夕食の有無
  - 料金プラン
  - 禁煙・喫煙
- 各処理がクラスごとに分けられておらず、拡張性が低い

## WHAT

- ホテルのオプションが考慮されるようになる
- 各処理をクラスごとに分けられている

## HOW

code_review/work/koki-sato/PHASE2/step1/sample.php の修正

## TODO

- [x] 学割料金を求めるメソッドを完成させる
- [x] 往復代を求めるメソッドを追加する
- [x] 喫煙可能部屋を使うメソッドを追加する
- [x] ホテルのランクを選択するメソッドを追加する
- [x] 朝食を食べるメソッドを追加する
- [x] 夕食を食べるメソッドを追加する
- [x] 配列 `$prices` に引数の値ををそれぞれ格納する
- [x] 配列の合計金額を求める処理を完成させる