### PR TITLE
クラスごとにファイルを分割

### DIFF
--- a/code_review/work/koki-sato/PHASE2/step2/HotelPlan.php
+++ b/code_review/work/koki-sato/PHASE2/step2/HotelPlan.php
@@ -1,0 +1,61 @@
+<?php
+// PHASE.2 step.2 HotelPlanクラスを作成する
+
+class HotelPlan
+{
+    // 喫煙ルームオプション代
+    const SMOKER_COST = 1000;
+    // ホテルの部屋別ランク料金
+    const HOTEL_ROOM_RANK_ADD_FEES = [
+        'normal' => 0,
+        'bronze' => 3000,
+        'silver' => 5000,
+        'gold' => 8000
+    ];
+    // 食事料金
+    const MEAL_ADD_FEES = [
+        'breakfast' => 500,
+        'dinner' => 800
+    ];
+
+    private $price = 0;
+
+
+    public function __construct($price)
+    {
+        $this->price = $price;
+    }
+
+    // PHASE.2 step.1 喫煙可能部屋を使うメソッドを追加する
+    public function useSmokingRoom()
+    {
+        $this->price += self::SMOKER_COST;
+    }
+
+    // PHASE.2 step.1 ホテルのランクを選択するメソッドを追加する
+    public function selectHotelRank($hotel_rank)
+    {
+        if (!array_key_exists($hotel_rank, self::HOTEL_ROOM_RANK_ADD_FEES)) {
+            echo "正しいランクを選択して下さい\n";
+            exit;
+        }
+        $this->price += self::HOTEL_ROOM_RANK_ADD_FEES[$hotel_rank];
+    }
+
+    // PHASE.2 step.1 朝食を食べるメソッドを追加する
+    public function eatBreakfast()
+    {
+        $this->price += self::MEAL_ADD_FEES['breakfast'];
+    }
+
+    // PHASE.2 step.1 夕食を食べるメソッドを追加する
+    public function eatDinner()
+    {
+        $this->price += self::MEAL_ADD_FEES['dinner'];
+    }
+
+    public function getTotalPrice()
+    {
+        return $this->price;
+    }
+}

--- a/code_review/work/koki-sato/PHASE2/step2/TrainPlan.php
+++ b/code_review/work/koki-sato/PHASE2/step2/TrainPlan.php
@@ -1,0 +1,26 @@
+<?php
+// PHASE.2 step.2 TrainPlanクラスを作成する
+
+class TrainPlan
+{
+    const STUDENT_DISCOUNT_COEFFICIENT = 0.2;
+    private $price = 0;
+
+
+    function __construct($price)
+    {
+        $this->price = $price;
+    }
+
+    public function useStudentDiscount()
+    {
+        // PHASE.2 step.1 学割料金を求めるメソッドを完成させる
+        $this->price = floor($this->price * (1 - self::STUDENT_DISCOUNT_COEFFICIENT));
+    }
+
+    // PHASE.2 step.1 往復代を求めるメソッドを追加する
+    public function getRoundTripPrice()
+    {
+        return $this->price * 2;
+    }
+}

--- a/code_review/work/koki-sato/PHASE2/step2/TravelPrice.php
+++ b/code_review/work/koki-sato/PHASE2/step2/TravelPrice.php
@@ -1,0 +1,22 @@
+<?php
+// PHASE.2 step.2 travelPriceクラスを作成する
+
+class TravelPrice
+{
+    private $total_price = 0;
+    private $prices = [];
+
+    public function __construct($round_trip_price, $hotel_price)
+    {
+        // PHASE.2 step.1 配列"$prices"に引数の値ををそれぞれ格納する
+        $this->prices['round_trip_price'] = $round_trip_price;
+        $this->prices['hotel_price'] = $hotel_price;
+    }
+
+    public function getTotalPrice()
+    {
+        // PHASE.2 step.1 配列の合計金額を求める処理を完成させる
+        $this->total_price = array_sum($this->prices);
+        return $this->total_price;
+    }
+}

--- a/code_review/work/koki-sato/PHASE2/step2/sample.php
+++ b/code_review/work/koki-sato/PHASE2/step2/sample.php
@@ -1,0 +1,34 @@
+<?php
+
+// PHASE.2 step.2 3つのクラスをrequireする
+require_once 'TrainPlan.php';
+require_once 'HotelPlan.php';
+require_once 'TravelPrice.php';
+
+/**
+ * 交通費を求める
+ **/
+$train_plan = new TrainPlan(12500);
+$train_plan->useStudentDiscount();
+$round_trip = $train_plan->getRoundTripPrice();
+
+echo "交通費： " . $round_trip . "円\n";
+
+/**
+ * ホテル代を求める
+ **/
+$hotel_plan = new HotelPlan(5000);
+$hotel_plan->eatBreakfast();
+$hotel_plan->eatDinner();
+$hotel_plan->useSmokingRoom();
+$hotel_plan->selectHotelRank('silver');
+$hotel_price = $hotel_plan->getTotalPrice();
+
+echo "ホテル代： " . $hotel_price . "円\n";
+
+/**
+ * 旅費合計を求める
+ **/
+$travel_price = new TravelPrice($round_trip, $hotel_price);
+$total_price = $travel_price->getTotalPrice();
+echo "旅費合計： " . $total_price . "円\n";


### PR DESCRIPTION
## WHY

#8 [各処理をクラスごとに分ける](https://github.com/beenos-inc/internship-contents/pull/8) にて各処理をクラスごとに分けたが、依然としてファイルは1つのままなので長くて読みづらい

## WHAT

- 各クラスごとにファイルが分割されている
- 1つのファイルが見やすくなる
- ファイル名とクラス名が対応することで、どのファイルにどのクラスが書かれているか明確になる

## HOW

code_review/work/koki-sato/PHASE2/step1/sample.php に書かれている3つのクラスを、それぞれ `TrainPlan.php` 、 `HotelPlan.php` 、 `TravelPrice.php` として切り出し、 `sample.php` にて3つのファイルを require する

## TODO

- [x] `TrainPlan.php` の切り出し
- [x] `HotelPlan.php` の切り出し
- [x] `TravelPrice.php` の切り出し
- [x] `sample.php` で上記3ファイルを読み込む